### PR TITLE
columnがnilの時はdefault_urlを返す #33

### DIFF
--- a/lib/resizing/carrier_wave.rb
+++ b/lib/resizing/carrier_wave.rb
@@ -32,7 +32,7 @@ module Resizing
     end
 
     def url(*args)
-      return nil unless read_column.present?
+      return default_url unless read_column.present?
 
       transforms = args.map do |version|
         version = version.intern
@@ -40,15 +40,20 @@ module Resizing
         versions[version].transform_string
       end.compact
 
-      "#{default_url}/#{transforms.join('/')}"
+      "#{build_url}/#{transforms.join('/')}"
     end
 
     def read_column
       model.read_attribute(serialization_column)
     end
 
-    def default_url
+    def build_url
       "#{Resizing.configure.host}#{model.read_attribute(serialization_column)}"
+    end
+
+    # need override this. if you want to return some url when target_column is nil
+    def default_url
+      nil
     end
 
     def transform_string

--- a/test/resizing/carrier_wave_test.rb
+++ b/test/resizing/carrier_wave_test.rb
@@ -70,6 +70,18 @@ module Resizing
       assert_equal('jpg', model.resizing_picture.format)
     end
 
+    def test_url_is_return_default_url
+      model = TestModel.new
+      model.save!
+      assert_nil model.resizing_picture_url
+    end
+
+    def test_url_is_return_default_url
+      model = TestModelWithDefaultURL.new
+      model.save!
+      assert_equal('http://example.com/test.jpg', model.resizing_picture_url)
+    end
+
     def expect_url
       'http://192.168.56.101:5000/projects/098a2a0d-c387-4135-a071-1254d6d7e70a/'+
         'upload/images/28c49144-c00d-4cb5-8619-98ce95977b9c/v1Id850__tqNsnoGWWUibtIBZ5NgjV45M'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,7 +33,7 @@ ActiveRecord::Base.establish_connection(
 ActiveRecord::Schema.define do
   self.verbose = false
 
-  %i(test_models test_jpg_models).each do |model_name|
+  %i(test_models test_jpg_models test_model_with_default_urls).each do |model_name|
     connection.execute "drop table if exists #{model_name}"
 
     create_table model_name do |t|
@@ -61,6 +61,20 @@ class ResizingJPGUploader < CarrierWave::Uploader::Base
   def default_format
     'jpg'
   end
+
+  def default_url
+    'http://example.com/test.jpg'
+  end
+end
+
+class ResizingUploaderWithDefaultURL < CarrierWave::Uploader::Base
+  include Resizing::CarrierWave
+
+  process resize_to_limit: [1000]
+
+  def default_url
+    'http://example.com/test.jpg'
+  end
 end
 
 class TestModel < ::ActiveRecord::Base
@@ -73,4 +87,10 @@ class TestJPGModel < ::ActiveRecord::Base
   extend CarrierWave::Mount
 
   mount_uploader :resizing_picture, ResizingJPGUploader
+end
+
+class TestModelWithDefaultURL < ::ActiveRecord::Base
+  extend CarrierWave::Mount
+
+  mount_uploader :resizing_picture, ResizingUploaderWithDefaultURL
 end


### PR DESCRIPTION

return default_url if target column is nil. default_url is return nil… s default. if you want to return some url when column is nil. you should be override default_url method.