### PR TITLE
CIテストにRailsバージョンマトリックスを追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,27 @@ permissions:
 
 jobs:
   test:
+    name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }}
     strategy:
       fail-fast: false
       matrix:
         ruby: ['3.1', '3.2','3.3', '3.4']
+        rails: ['6.1', '7.0', '7.1', '7.2']
+        exclude:
+          # Rails 7.2 requires Ruby 3.1+
+          - ruby: '3.1'
+            rails: '7.2'
+          # Rails 7.1 requires Ruby 3.1+
+          - ruby: '3.1'
+            rails: '7.1'
+          # Rails 6.1 requires Ruby under 3.3
+          - ruby: '3.4'
+            rails: '6.1'
 
     runs-on: ubuntu-22.04
+
+    env:
+      RAILS_VERSION: ${{ matrix.rails }}
 
     steps:
       - uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,10 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in resizing.gemspec
 gemspec
 
+# Allow testing against different Rails versions
+rails_version = ENV['RAILS_VERSION'] || '7.0'
+gem 'rails', "~> #{rails_version}"
+
 gem 'rake', '~> 13.0'
 gem 'github_changelog_generator'
 gem 'mysql2'

--- a/resizing.gemspec
+++ b/resizing.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.add_runtime_dependency 'faraday', '~> 2.3'
   spec.add_runtime_dependency 'faraday-multipart'
-  spec.add_development_dependency 'rails', '> 6.0'
   spec.add_development_dependency 'carrierwave', '~> 2.2.5'
   spec.add_development_dependency 'fog-aws'
   spec.add_development_dependency 'minitest', '~> 5.16'


### PR DESCRIPTION
## 説明
複数のRailsバージョン（6.1、7.0、7.1、7.2）と異なるRubyバージョン（3.1、3.2、3.3、3.4）の組み合わせでテストするようにCIを設定しました。

## 変更内容
- GitHub ActionsワークフローにRailsバージョンマトリックスを追加
- GemfileでRAILS_VERSION環境変数を使用してRailsバージョンを制御
- gemspecからハードコードされたRailsバージョンを削除
- 互換性のないRuby/Railsの組み合わせを除外設定に追加
- ジョブ名にRubyとRailsのバージョンを表示して分かりやすく改善
