### PR TITLE
Add test for remove_resizing_picture flag with save pattern

### DIFF
--- a/test/resizing/carrier_wave_test.rb
+++ b/test/resizing/carrier_wave_test.rb
@@ -57,6 +57,24 @@ module Resizing
       assert model.resizing_picture.blank?, 'resizing_picture should be blank for new record'
     end
 
+    def test_remove_resizing_picture_with_flag_and_save
+      model = prepare_model TestModel
+      model.save!
+
+      refute model.resizing_picture.blank?, 'resizing_picture should not be blank before remove'
+
+      model.remove_resizing_picture = true
+
+      # フラグを設定した時点ではHTTP通信は発生しない
+      # save時に削除が実行される
+      VCR.use_cassette 'carrier_wave_test/remove_resizing_picture' do
+        model.save!
+      end
+
+      assert model.resizing_picture.blank?, 'resizing_picture should be blank after save'
+      assert_nil model.resizing_picture_url
+    end
+
     def test_picture_url_return_correct_value_and_when_model_reloaded
       model = prepare_model TestModel
       model.save!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,6 +28,7 @@ require 'rails'
 require 'active_record'
 require 'fog-aws'
 require 'carrierwave'
+require 'carrierwave/orm/activerecord'
 require 'resizing'
 require 'pry-byebug'
 
@@ -103,19 +104,13 @@ class ResizingUploaderWithDefaultURL < CarrierWave::Uploader::Base
 end
 
 class TestModel < ::ActiveRecord::Base
-  extend CarrierWave::Mount
-
   mount_uploader :resizing_picture, ResizingUploader
 end
 
 class TestJPGModel < ::ActiveRecord::Base
-  extend CarrierWave::Mount
-
   mount_uploader :resizing_picture, ResizingJPGUploader
 end
 
 class TestModelWithDefaultURL < ::ActiveRecord::Base
-  extend CarrierWave::Mount
-
   mount_uploader :resizing_picture, ResizingUploaderWithDefaultURL
 end


### PR DESCRIPTION
## Summary
CarrierWaveのremove_xxx + saveパターンのテストを追加しました。

## Changes
- `test_helper.rb`に`require 'carrierwave/orm/activerecord'`を追加し、ActiveRecord統合を有効化
- テストモデルから不要な`extend CarrierWave::Mount`を削除
- `test_remove_resizing_picture_with_flag_and_save`テストケースを追加

## Background
CarrierWaveには2つの削除パターンがあります：
2. `remove_resizing_picture = true` + `save` - save時に削除が実行される

今回、2番目のパターンのテストを追加しました。また、`CarrierWave::ActiveRecord`が正しく読み込まれるよう設定を修正しました。