### PR TITLE
Support both Faraday 1.x and 2.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,17 +12,19 @@ permissions:
 
 jobs:
   test:
-    name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }}
+    name: Ruby ${{ matrix.ruby }} / Rails ${{ matrix.rails }} / Faraday ${{ matrix.faraday }}
     strategy:
       fail-fast: false
       matrix:
         ruby: ['3.1']
         rails: ['6.1', '7.0']
+        faraday: ['1.0', '2.0']
 
     runs-on: ubuntu-22.04
 
     env:
       RAILS_VERSION: ${{ matrix.rails }}
+      FARADAY_VERSION: ${{ matrix.faraday }}
 
     steps:
       - uses: actions/checkout@v4
@@ -50,6 +52,10 @@ jobs:
       - name: bundle install
         run: |
           bundle install
+
+      - name: Show Faraday version
+        run: |
+          bundle list | grep faraday
 
       - name: Run test
         run: |

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,10 @@ gemspec
 rails_version = ENV['RAILS_VERSION'] || '7.0'
 gem 'rails', "~> #{rails_version}"
 
+# Allow testing against different Faraday versions
+faraday_version = ENV['FARADAY_VERSION'] || '2.0'
+gem 'faraday', "~> #{faraday_version}"
+
 gem 'byebug'
 gem 'github_changelog_generator'
 gem 'mysql2'

--- a/lib/resizing.rb
+++ b/lib/resizing.rb
@@ -6,6 +6,15 @@ require 'faraday/multipart'
 require 'json'
 
 module Resizing
+  # Faraday 1.x uses Faraday::UploadIO, Faraday 2.x uses Faraday::Multipart::FilePart
+  def self.file_part_class
+    if defined?(Faraday::Multipart::FilePart)
+      Faraday::Multipart::FilePart
+    else
+      Faraday::UploadIO
+    end
+  end
+
   autoload :Constants, 'resizing/constants'
   autoload :Configurable, 'resizing/configurable'
   autoload :HttpClientable, 'resizing/http_clientable'

--- a/lib/resizing/client.rb
+++ b/lib/resizing/client.rb
@@ -45,7 +45,7 @@ module Resizing
 
       url = build_post_url
       params = {
-        image: Faraday::Multipart::FilePart.new(filename_or_io, options[:content_type], filename)
+        image: Resizing.file_part_class.new(filename_or_io, options[:content_type], filename)
       }
 
       response = handle_faraday_error do
@@ -64,7 +64,7 @@ module Resizing
 
       url = build_put_url(image_id)
       params = {
-        image: Faraday::Multipart::FilePart.new(filename_or_io, options[:content_type], filename)
+        image: Resizing.file_part_class.new(filename_or_io, options[:content_type], filename)
       }
 
       response = handle_faraday_error do

--- a/resizing.gemspec
+++ b/resizing.gemspec
@@ -26,7 +26,8 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0")
   end
   spec.require_paths = ['lib']
-  spec.add_runtime_dependency 'faraday', '~> 1.0'
+  spec.add_runtime_dependency 'faraday', '>= 1.0', '< 3'
+  spec.add_runtime_dependency 'faraday-multipart', '>= 1.0'
   spec.add_development_dependency 'rails', ">= 6.0", '< 7.1'
   spec.add_development_dependency 'carrierwave', '~> 1.3.2'
   spec.add_development_dependency 'fog-aws'

--- a/test/resizing_test.rb
+++ b/test/resizing_test.rb
@@ -6,4 +6,20 @@ class ResizingTest < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::Resizing::VERSION
   end
+
+  def test_file_part_class_returns_valid_class
+    klass = Resizing.file_part_class
+    # Should return either Faraday::Multipart::FilePart (Faraday 2.x) or Faraday::UploadIO (Faraday 1.x)
+    assert [Faraday::Multipart::FilePart, Faraday::UploadIO].include?(klass),
+           "Expected Faraday::Multipart::FilePart or Faraday::UploadIO, got #{klass}"
+  end
+
+  def test_file_part_class_returns_faraday_multipart_file_part_when_defined
+    # Faraday::Multipart::FilePart is defined when faraday-multipart gem is loaded
+    if defined?(Faraday::Multipart::FilePart)
+      assert_equal Faraday::Multipart::FilePart, Resizing.file_part_class
+    else
+      assert_equal Faraday::UploadIO, Resizing.file_part_class
+    end
+  end
 end


### PR DESCRIPTION
## Summary
This PR adds support for both Faraday 1.x and 2.x versions.

## Changes
- Update gemspec to allow Faraday >= 1.0, < 3
- Add `faraday-multipart` as runtime dependency
- Add `Resizing.file_part_class` helper method for version compatibility
  - Faraday 2.x: uses `Faraday::Multipart::FilePart`
  - Faraday 1.x: uses `Faraday::UploadIO`
- Update `client.rb` to use version-compatible file part class
- Add Faraday version matrix (1.0, 2.0) to GitHub Actions CI
- Update Gemfile to support `FARADAY_VERSION` environment variable

## Testing
All tests pass with both Faraday 1.x and 2.x:
- Ruby 3.1 / Rails 6.1 / Faraday 1.0
- Ruby 3.1 / Rails 6.1 / Faraday 2.0
- Ruby 3.1 / Rails 7.0 / Faraday 1.0
- Ruby 3.1 / Rails 7.0 / Faraday 2.0