### PR TITLE
Fix: 画像更新時に古い画像が削除されない問題を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,9 @@
 /pkg/
 /spec/reports/
 /tmp/
+vendor/
+Gemfile.lock
+tags
+sample1.jpg
+.ruby-version
+uploads/

--- a/lib/resizing/carrier_wave.rb
+++ b/lib/resizing/carrier_wave.rb
@@ -29,11 +29,20 @@ module Resizing
     def initialize(*args)
       @requested_format = nil
       @default_format = nil
+      @retrieved_identifier = nil
       super
     end
 
+    # Override to store the identifier and set up @file for later use
+    def retrieve_from_store!(identifier)
+      @retrieved_identifier = identifier
+      super
+      # Ensure @file is set up so that remove! can call @file.delete
+      file
+    end
+
     def file
-      file_identifier = identifier || read_column
+      file_identifier = @retrieved_identifier || identifier || read_column
 
       return nil if file_identifier.blank?
 

--- a/test/vcr/carrier_wave_test/update_image.yml
+++ b/test/vcr/carrier_wave_test/update_image.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://192.168.56.101:5000/projects/e06e710d-f026-4dcf-b2c0-eab0de8bb83f/upload/images/
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"id":"old-image-id-1111-1111-111111111111","project_id":"e06e710d-f026-4dcf-b2c0-eab0de8bb83f","content_type":"image/jpeg","version":"v1","public_id":"/projects/e06e710d-f026-4dcf-b2c0-eab0de8bb83f/upload/images/old-image-id-1111-1111-111111111111/v1"}'
+  recorded_at: Sun, 11 Oct 2020 04:56:48 GMT
+- request:
+    method: post
+    uri: http://192.168.56.101:5000/projects/e06e710d-f026-4dcf-b2c0-eab0de8bb83f/upload/images/
+    body:
+      encoding: ASCII-8BIT
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"id":"new-image-id-2222-2222-222222222222","project_id":"e06e710d-f026-4dcf-b2c0-eab0de8bb83f","content_type":"image/jpeg","version":"v2","public_id":"/projects/e06e710d-f026-4dcf-b2c0-eab0de8bb83f/upload/images/new-image-id-2222-2222-222222222222/v2"}'
+  recorded_at: Sun, 11 Oct 2020 04:56:49 GMT
+- request:
+    method: delete
+    uri: http://192.168.56.101:5000/projects/e06e710d-f026-4dcf-b2c0-eab0de8bb83f/upload/images/old-image-id-1111-1111-111111111111
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      content-type:
+      - application/json; charset=utf-8
+    body:
+      encoding: UTF-8
+      string: '{"id":"old-image-id-1111-1111-111111111111","project_id":"e06e710d-f026-4dcf-b2c0-eab0de8bb83f"}'
+  recorded_at: Sun, 11 Oct 2020 04:56:50 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
## 概要
モデルに添付された画像を更新する際、古い画像がResizingストレージから削除されない問題を修正しました。

## 変更内容

### 問題

### 解決策
2. **`current_path`を修正** - `storage/file.rb`で`@public_id`がセットされている場合は`@public_id.to_s`を返すように変更
3. **`clear_column_if_current_image`を追加** - 削除する画像が現在の画像と一致する場合のみカラムをクリアするように変更（古い画像削除時に新しい画像IDが消えないようにする）

### テスト
- `test_delete_is_called_when_image_is_updated`を追加し、画像更新時にDELETEリクエストが発行されることを確認
- VCRカセット`update_image.yml`を追加（POST x2, DELETE x1）

## 補足
`Storage::File`がCarrierWaveに委譲せずに直接カラムを更新する必要がある理由について、ドキュメントコメントを追加しました（CarrierWaveの`identifier`チェーンとresizing-gemの`filename`メソッドの関係による）。